### PR TITLE
fix: update for ipfs-http-client >= 27.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "inet_ipv4": "^1.0.0",
     "memoizee": "~0.4.11",
-    "multihashes": "^0.4.12"
+    "multihashes": "~0.4.12"
   },
   "repository": {
     "type": "git",
@@ -32,8 +32,8 @@
     "csv": "^2.0.0",
     "gauge": "^2.7.4",
     "iconv-lite": "~0.4.19",
-    "ipfs": "^0.33.1",
-    "ipfsd-ctl": "^0.40.2",
+    "ipfs": "~0.33.1",
+    "ipfsd-ctl": "~0.40.2",
     "lodash": "^4.17.4",
     "pre-commit": "^1.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/ipfs/ipfs-geoip"
   },
   "devDependencies": {
-    "aegir": "^12.1.3",
+    "aegir": "^18.0.2",
     "bl": "^1.2.1",
     "bluebird": "^3.5.1",
     "chai": "^4.1.2",
@@ -32,8 +32,8 @@
     "csv": "^2.0.0",
     "gauge": "^2.7.4",
     "iconv-lite": "~0.4.19",
-    "ipfs-api": "^15.0.1",
-    "ipfsd-ctl": "~0.24.1",
+    "ipfs": "^0.33.1",
+    "ipfsd-ctl": "^0.40.2",
     "lodash": "^4.17.4",
     "pre-commit": "^1.2.2"
   },

--- a/src/generate/index.js
+++ b/src/generate/index.js
@@ -213,7 +213,7 @@ function main (ipfs) {
     .then((result) => {
       emit('node', 'end')
       emit('pinning', 'start')
-      return ipfs.pin.add(result.hash, {recursive: true})
+      return ipfs.pin.add(result.hash, { recursive: true })
     })
     .then((result) => {
       emit('pinning', 'end')

--- a/src/lookup.js
+++ b/src/lookup.js
@@ -61,7 +61,7 @@ function _lookup (ipfs, hash, lookfor, cb) {
   })
 }
 
-memoizedLookup = memoize(_lookup, {async: true})
+memoizedLookup = memoize(_lookup, { async: true })
 
 module.exports = function lookup (ipfs, ip, cb) {
   memoizedLookup(ipfs, GEOIP_ROOT, inet.aton(ip), cb)

--- a/src/pretty.js
+++ b/src/pretty.js
@@ -12,7 +12,6 @@ function isLocal (address) {
 }
 
 module.exports = function lookupPretty (ipfs, multiaddrs, cb) {
-  console.log('lookupPretty', multiaddrs.length, multiaddrs)
   if (multiaddrs.length === 0) {
     return cb(new Error('lookup requires a multiaddr array with length > 0'), null)
   }

--- a/src/pretty.js
+++ b/src/pretty.js
@@ -12,6 +12,7 @@ function isLocal (address) {
 }
 
 module.exports = function lookupPretty (ipfs, multiaddrs, cb) {
+  console.log('lookupPretty', multiaddrs.length, multiaddrs)
   if (multiaddrs.length === 0) {
     return cb(new Error('lookup requires a multiaddr array with length > 0'), null)
   }
@@ -25,7 +26,11 @@ module.exports = function lookupPretty (ipfs, multiaddrs, cb) {
 
   // No ip6 support at the moment
   if (isLocal(address) || current[1] === 'ip6') {
-    return lookupPretty(ipfs, multiaddrs.slice(1), cb)
+    const next = multiaddrs.slice(1)
+    if (next.length > 0 ) {
+      return lookupPretty(ipfs, multiaddrs.slice(1), cb)
+    }
+    return cb(new Error('Unmapped range'), null)
   }
 
   lookup(ipfs, address, (err, res) => {

--- a/src/pretty.js
+++ b/src/pretty.js
@@ -26,7 +26,7 @@ module.exports = function lookupPretty (ipfs, multiaddrs, cb) {
   // No ip6 support at the moment
   if (isLocal(address) || current[1] === 'ip6') {
     const next = multiaddrs.slice(1)
-    if (next.length > 0 ) {
+    if (next.length > 0) {
       return lookupPretty(ipfs, multiaddrs.slice(1), cb)
     }
     return cb(new Error('Unmapped range'), null)

--- a/test/generate.spec.js
+++ b/test/generate.spec.js
@@ -94,8 +94,8 @@ describe('generate', () => {
   it('putObject', () => {
     const api = {
       object: {
-        put: () => Promise.resolve({Hash: 'myhash'}),
-        stat: (hash) => Promise.resolve({CumulativeSize: 5})
+        put: () => Promise.resolve({ Hash: 'myhash' }),
+        stat: (hash) => Promise.resolve({ CumulativeSize: 5 })
       }
     }
 
@@ -111,8 +111,8 @@ describe('generate', () => {
   it('toNode', () => {
     const api = {
       object: {
-        put: (val) => Promise.resolve({Hash: 'myhash' + val.length}),
-        stat: (hash) => Promise.resolve({CumulativeSize: hash.length})
+        put: (val) => Promise.resolve({ Hash: 'myhash' + val.length }),
+        stat: (hash) => Promise.resolve({ CumulativeSize: hash.length })
       }
     }
 

--- a/test/lookup.spec.js
+++ b/test/lookup.spec.js
@@ -2,24 +2,19 @@
 'use strict'
 
 const expect = require('chai').expect
-
 const geoip = require('../src')
-const IPFS = require('ipfs-api')
-const ctl = require('ipfsd-ctl')
+const IPFSFactory = require('ipfsd-ctl')
+const factory = IPFSFactory.create({ type: 'js' })
 
 describe('lookup', function () {
   this.timeout(100 * 1000)
   let ipfs
 
   before((done) => {
-    ctl.disposable((err, node) => {
+    factory.spawn((err, ipfsd) => {
       if (err) throw err
-
-      node.startDaemon((err) => {
-        if (err) throw err
-        ipfs = IPFS(node.apiAddr)
-        done()
-      })
+      ipfs = ipfsd.api
+      done()
     })
   })
 


### PR DESCRIPTION
- Fix test error where `lookupPretty` would return an different error for local IP lookups to `lookup`
- Deal with old dag node links that have a `.multihash` property and new ones that have  a `.cid` property.
- Update ipfsd-ctl and refactor test
- Update aegir
- Fix lint errors

Fixes #65 