### PR TITLE
refactor: IPFS_GATEWAY

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,16 @@ in multiple locations,  and stored as the new `GEOIP_ROOT` in `src/lookup.js`
 
 ## Testing in CLI
 
+It is possible to run tests against a local gateway by passing `IPFS_GATEWAY`:
+
+```console
+$ IPFS_GATEWAY="http://127.0.0.1:8080" npm test
+```
+
 You can find an example of how to use this in [`example/lookup.js`](example/lookup.js), which you can use like this:
 
 ```bash
+$ export IPFS_GATEWAY="http://127.0.0.1:8080"
 $ node example/lookup.js 66.6.44.4
 Result: {
   "country_name": "USA",

--- a/example/lookup.js
+++ b/example/lookup.js
@@ -1,8 +1,7 @@
 import * as geoip from '../src/index.js'
 import { create } from 'ipfs-http-client'
 
-// This CLI tool requires Kubo RPC on 127.0.0.1:5001 to be running
-const ipfs = create(new URL('http://127.0.0.1:5001'))
+const ipfsGw = process?.env?.IPFS_GATEWAY || 'https://ipfs.io'
 
 if (process.argv.length !== 3) {
   console.log('usage: node lookup.js <ip4-adr>')
@@ -11,14 +10,14 @@ if (process.argv.length !== 3) {
 
 (async function() {
   try {
-    const result = await geoip.lookup(ipfs, process.argv[2])
+    const result = await geoip.lookup(ipfsGw, process.argv[2])
     console.log('Result: ' + JSON.stringify(result, null, 2))
   } catch (err) {
     console.log('Error: ' + err)
   }
 
   try {
-    const result = await geoip.lookupPretty(ipfs, '/ip4/' + process.argv[2])
+    const result = await geoip.lookupPretty(ipfsGw, '/ip4/' + process.argv[2])
     console.log('Pretty result: %s', result.formatted)
   } catch (err) {
     console.log('Error: ' + err)

--- a/test/lookup.spec.js
+++ b/test/lookup.spec.js
@@ -4,7 +4,7 @@ import * as geoip from '../src/index.js'
 describe('lookup via HTTP Gateway supporting application/vnd.ipld.raw responses', function () {
   this.timeout(100 * 1000)
 
-  const ipfsGW = 'https://ipfs.io'
+  const ipfsGW = process?.env?.IPFS_GATEWAY || 'https://ipfs.io'
 
   it('fails on 127.0.0.1', async () => {
     try {

--- a/test/lookup.spec.js
+++ b/test/lookup.spec.js
@@ -4,18 +4,18 @@ import * as geoip from '../src/index.js'
 describe('lookup via HTTP Gateway supporting application/vnd.ipld.raw responses', function () {
   this.timeout(100 * 1000)
 
-  const ipfs = process.env.CI ? 'https://ipfs.io' : 'http://127.0.0.1:8080'
+  const ipfsGW = 'https://ipfs.io'
 
   it('fails on 127.0.0.1', async () => {
     try {
-      await geoip.lookup(ipfs, '127.0.0.1')
+      await geoip.lookup(ipfsGW, '127.0.0.1')
     } catch (err) {
       expect(err).to.have.property('message', 'Unmapped range')
     }
   })
 
   it('looks up 66.6.44.4', async () => {
-    const result = await geoip.lookup(ipfs, '66.6.44.4')
+    const result = await geoip.lookup(ipfsGW, '66.6.44.4')
     expect(
       result
     ).to.be.eql({
@@ -33,14 +33,14 @@ describe('lookup via HTTP Gateway supporting application/vnd.ipld.raw responses'
   describe('lookupPretty', () => {
     it('fails on 127.0.0.1', async () => {
       try {
-        await geoip.lookupPretty(ipfs, '/ip4/127.0.0.1')
+        await geoip.lookupPretty(ipfsGW, '/ip4/127.0.0.1')
       } catch (err) {
         expect(err).to.have.property('message', 'Unmapped range')
       }
     })
 
     it('looks up 66.6.44.4', async () => {
-      const result = await geoip.lookupPretty(ipfs, '/ip4/66.6.44.4')
+      const result = await geoip.lookupPretty(ipfsGW, '/ip4/66.6.44.4')
       expect(
         result.formatted
       ).to.be.eql('Ashburn, VA, USA, Earth')


### PR DESCRIPTION
Original PR: #93

In this PR:

- [x] fix / update npm test
- [x] TBD - maybe we should only support gateways?
- [x] confirm it works with ipfs.block.get from Kubo
- [x] confirm it works with ipfs.block.get from JS-IPFS
- [x] https://github.com/ipfs/public-gateway-checker (refactor to use gateway)
- [x] solve issue with ip dependency requiring native node module (check this PR: https://github.com/ipfs/public-gateway-checker/pull/319)


<img width="1575" alt="dag-cbor-ipfs-geoip" src="https://user-images.githubusercontent.com/1895906/196363755-013e86e6-6d78-43da-9217-4bb5b74d61a8.png">


Remaining
- [ ] update source dataset and regenerate b-tree, so users not only get storage savings thanks to DAG-CBOR, but also get updated GeoIP database
- [ ] cleanup add retry if gateway timeouts
- [ ] confirm it works with https://github.com/ipfs/ipfs-webui (refactor to use `availableGatewayUrl` and pass it similar to how we do it on [explore page](https://github.com/ipfs/ipfs-webui/blob/f3a886568a9045318ee340c1b5ebe811f7d9de04/src/explore/ExploreContainer.js))