### PR TITLE
feat: updated dataset (2022-10-18)

### DIFF
--- a/src/generate/index.js
+++ b/src/generate/index.js
@@ -20,7 +20,7 @@ const CHILDREN = 32
 //     DATA_HASH
 //     |- locationsCsv
 //     |- blocksCsv
-const DATA_HASH = 'bafybeiacaphdy5t63opus5mzeerco7ckpbyqathghnxnf732xdwvrk73qm' // GeoLite2-City-CSV_20220628
+const DATA_HASH = 'bafybeicfcxk4bx3nwmg3hwjmlc6n2qzn73mfm5itfpadwh5w7bux2chgz4' // GeoLite2-City-CSV_20221018
 const locationsCsv = 'GeoLite2-City-Locations-en.csv'
 const blocksCsv = 'GeoLite2-City-Blocks-IPv4.csv'
 

--- a/src/lookup.js
+++ b/src/lookup.js
@@ -5,7 +5,7 @@ import { CID } from 'multiformats/cid'
 import fetch from 'cross-fetch'
 import { formatData } from './format.js'
 
-export const GEOIP_ROOT = CID.parse('bafyreihpmffy4un3u3qstv5bskxmdekdzydujbbephdwhshrgbrecjnqme') // GeoLite2-City-CSV_20220628
+export const GEOIP_ROOT = CID.parse('bafyreihnpl7ami7esahkfdnemm6idx4r2n6u3apmtcrxlqwuapgjsciihy') // b-tree version of GeoLite2-City-CSV_20221018
 
 const defaultGateway = ['https://ipfs.io', 'https://dweb.link']
 
@@ -28,9 +28,15 @@ async function getRawBlock (ipfs, cid) {
   for (const url of gateways) { // eslint-disable-line no-unreachable-loop
     const gwUrl = new URL(url)
     gwUrl.pathname = `/ipfs/${cid.toString()}`
-    gwUrl.search = '?format=raw'
+    gwUrl.search = '?format=raw' // necessary as not every gateway supports dag-cbor, but every should support sending raw block as-is
     try {
-      const res = await fetch(gwUrl, { cache: 'force-cache' })
+      const res = await fetch(gwUrl, {
+        headers: {
+          // also set header, just in case ?format= is filtered out by some reverse proxy
+          Accept: 'application/vnd.ipld.raw'
+        },
+        cache: 'force-cache'
+      })
       if (!res.ok) throw res
       return new Uint8Array(await res.arrayBuffer())
     } catch (cause) {

--- a/test/lookup.spec.js
+++ b/test/lookup.spec.js
@@ -24,9 +24,9 @@ describe('lookup via HTTP Gateway supporting application/vnd.ipld.raw responses'
       country_code: 'US',
       region_code: 'VA',
       city: 'Ashburn',
-      postal_code: '20103',
-      latitude: 39.0019,
-      longitude: -77.4556,
+      postal_code: '20149',
+      latitude: 39.0469,
+      longitude: -77.4903,
       planet: 'Earth'
     })
   })


### PR DESCRIPTION
This PR updates geoip dataset used for lookups:

- The source data was GeoLite2-City-CSV_20221018 (`bafybeicfcxk4bx3nwmg3hwjmlc6n2qzn73mfm5itfpadwh5w7bux2chgz4`)
- Generated b-tree (DAG-CBOR): `bafyreihnpl7ami7esahkfdnemm6idx4r2n6u3apmtcrxlqwuapgjsciihy` (~277 MiB)

Since we don't have #91  yet, I am pinning this manually to web3.storage/ and estuary.