### PR TITLE
chore: replace ipfs.io with trustless-gateway.link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ version `N.N.N` as a [remote copy from jsDelivr](https://www.jsdelivr.com/packag
 ```html
 <script type="module">
   import { lookup } from 'https://cdn.jsdelivr.net/npm/ipfs-geoip@N.N.N/dist/index.min.js';
-  const gateway = 'https://ipfs.io'
+  const gateway = 'https://trustless-gateway.link'
   console.log(await lookup(gateway, '66.6.44.4'))
 </script>
 ```
@@ -79,7 +79,7 @@ and parsing them as DAG-CBOR locally via [@ipld/dag-cbor](https://www.npmjs.com/
 const geoip = require('ipfs-geoip')
 const exampleIp = '66.6.44.4'
 
-const gateways = ['https://ipfs.io', 'https://dweb.link']
+const gateways = ['https://trustless-gateway.link', 'https://example.com']
 
 try {
   const result = await geoip.lookup(gateways, exampleIp)

--- a/bin/load-fixtures.sh
+++ b/bin/load-fixtures.sh
@@ -2,7 +2,7 @@
 
 function main() {
   local CID="$1"
-  curl -H "Accept: application/vnd.ipld.raw" "https://ipfs.io/ipfs/$CID?format=raw" > test/fixtures/$CID.raw.bin
+  curl -H "Accept: application/vnd.ipld.raw" "https://trustless-gateway.link/ipfs/$CID?format=raw" > test/fixtures/$CID.raw.bin
 }
 
 main "$@"

--- a/example/lookup.js
+++ b/example/lookup.js
@@ -1,6 +1,6 @@
 import * as geoip from '../src/index.js'
 
-const ipfsGw = process?.env?.IPFS_GATEWAY || 'https://ipfs.io'
+const ipfsGw = process?.env?.IPFS_GATEWAY || 'https://trustless-gateway.link'
 
 if (process.argv.length !== 3) {
   console.log('usage: node lookup.js <ip4-adr>')

--- a/src/lookup.js
+++ b/src/lookup.js
@@ -8,7 +8,7 @@ import { formatData } from './format.js'
 
 export const GEOIP_ROOT = CID.parse('bafyreibm6gpmdrbbf27x4b473fenradnlc3zcussd3vfjy4nv7ta3uuyge') // b-tree version of GeoLite2-City-CSV_20250218
 
-const defaultGateway = ['https://trustless-gateway.link', 'https://ipfs.io', 'https://dweb.link']
+const defaultGateway = ['https://trustless-gateway.link']
 
 /**
  * @param {object|string} ipfs

--- a/test/lookup.browser.spec.js
+++ b/test/lookup.browser.spec.js
@@ -4,7 +4,7 @@ import * as geoip from '../src/index.js'
 describe('lookup via HTTP Gateway supporting application/vnd.ipld.raw responses', function () {
   this.timeout(100 * 1000)
 
-  const ipfsGW = process?.env?.IPFS_GATEWAY || 'https://ipfs.io'
+  const ipfsGW = process?.env?.IPFS_GATEWAY || 'https://trustless-gateway.link'
 
   it('fails on 127.0.0.1', async () => {
     try {

--- a/test/lookupMultiple.node.spec.js
+++ b/test/lookupMultiple.node.spec.js
@@ -4,7 +4,7 @@ import esmock from 'esmock'
 import { MAX_LOOKUP_RETRIES } from '../src/constants.js'
 
 describe('[Runner Node]: lookup via HTTP Gateway supporting application/vnd.ipld.raw responses', function () {
-  const ipfsGW = process?.env?.IPFS_GATEWAY || 'https://ipfs.io'
+  const ipfsGW = process?.env?.IPFS_GATEWAY || 'https://trustless-gateway.link'
 
   let rewiredGeoIp
   let failedCalls = 0


### PR DESCRIPTION
ipfs.io serves deserialized responses and redirects to a trustless gateway for raw block requests, adding an extra round-trip per block fetch. switch all defaults, examples, tests, and docs to trustless-gateway.link to avoid this.